### PR TITLE
Document EventEmitter Abstraction

### DIFF
--- a/packages/core/docs/references/namespaces/Micra/README.md
+++ b/packages/core/docs/references/namespaces/Micra/README.md
@@ -29,8 +29,16 @@ class CustomServiceProvider implements Micra.ServiceProvider {
 
 ## Interfaces
 
+- [AddEventListenerOptions](interfaces/AddEventListenerOptions.md)
 - [ApplicationError](interfaces/ApplicationError.md)
 - [ErrorDetail](interfaces/ErrorDetail.md)
 - [ErrorOptions](interfaces/ErrorOptions.md)
 - [ErrorSerializerOptions](interfaces/ErrorSerializerOptions.md)
+- [Event](interfaces/Event.md)
+- [EventEmitter](interfaces/EventEmitter.md)
+- [EventListener](interfaces/EventListener.md)
 - [SerializedError](interfaces/SerializedError.md)
+
+## Type Aliases
+
+- [MatchGlobEvents](type-aliases/MatchGlobEvents.md)

--- a/packages/core/docs/references/namespaces/Micra/interfaces/AddEventListenerOptions.md
+++ b/packages/core/docs/references/namespaces/Micra/interfaces/AddEventListenerOptions.md
@@ -1,0 +1,41 @@
+[**@micra/core**](../../../README.md)
+
+***
+
+[@micra/core](../../../README.md) / [Micra](../README.md) / AddEventListenerOptions
+
+# Interface: AddEventListenerOptions
+
+Defined in: [event-emitter/index.d.ts:92](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/event-emitter/index.d.ts#L92)
+
+Defines options for event listeners, such as capture, once, and passive.
+
+## Properties
+
+### capture?
+
+> `optional` **capture**: `boolean`
+
+Defined in: [event-emitter/index.d.ts:96](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/event-emitter/index.d.ts#L96)
+
+Indicates if the event listener should be invoked during the capture phase.
+
+***
+
+### once?
+
+> `optional` **once**: `boolean`
+
+Defined in: [event-emitter/index.d.ts:101](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/event-emitter/index.d.ts#L101)
+
+Specifies if the listener should be removed after being invoked once.
+
+***
+
+### passive?
+
+> `optional` **passive**: `boolean`
+
+Defined in: [event-emitter/index.d.ts:106](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/event-emitter/index.d.ts#L106)
+
+Indicates that the listener will never call `preventDefault()`, improving performance.

--- a/packages/core/docs/references/namespaces/Micra/interfaces/ApplicationError.md
+++ b/packages/core/docs/references/namespaces/Micra/interfaces/ApplicationError.md
@@ -6,7 +6,7 @@
 
 # Interface: ApplicationError
 
-Defined in: [error/index.d.ts:5](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L5)
+Defined in: [error/index.d.ts:5](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L5)
 
 Represents a structured error in the application.
 Supports metadata, nested error aggregation, and serialization.
@@ -17,7 +17,7 @@ Supports metadata, nested error aggregation, and serialization.
 
 > `optional` **detail**: `string`
 
-Defined in: [error/index.d.ts:7](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L7)
+Defined in: [error/index.d.ts:7](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L7)
 
 A human-readable explanation of the error.
 
@@ -27,7 +27,7 @@ A human-readable explanation of the error.
 
 > `readonly` **errors**: [`ApplicationError`](ApplicationError.md)[]
 
-Defined in: [error/index.d.ts:25](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L25)
+Defined in: [error/index.d.ts:25](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L25)
 
 A collection of nested errors related to this error.
 
@@ -37,7 +37,7 @@ A collection of nested errors related to this error.
 
 > `readonly` **hasErrors**: `boolean`
 
-Defined in: [error/index.d.ts:28](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L28)
+Defined in: [error/index.d.ts:28](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L28)
 
 Indicates whether there are any aggregated errors.
 
@@ -47,7 +47,7 @@ Indicates whether there are any aggregated errors.
 
 > `optional` **instance**: `string`
 
-Defined in: [error/index.d.ts:10](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L10)
+Defined in: [error/index.d.ts:10](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L10)
 
 A URI reference identifying the specific instance of the error.
 
@@ -57,7 +57,7 @@ A URI reference identifying the specific instance of the error.
 
 > `optional` **metadata**: `Record`\<`string`, `any`\>
 
-Defined in: [error/index.d.ts:13](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L13)
+Defined in: [error/index.d.ts:13](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L13)
 
 Additional metadata related to the error.
 
@@ -67,7 +67,7 @@ Additional metadata related to the error.
 
 > **status**: `number`
 
-Defined in: [error/index.d.ts:16](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L16)
+Defined in: [error/index.d.ts:16](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L16)
 
 HTTP status code associated with the error.
 
@@ -77,7 +77,7 @@ HTTP status code associated with the error.
 
 > **title**: `string`
 
-Defined in: [error/index.d.ts:19](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L19)
+Defined in: [error/index.d.ts:19](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L19)
 
 A short, human-readable title describing the error type.
 
@@ -87,7 +87,7 @@ A short, human-readable title describing the error type.
 
 > `optional` **type**: `string`
 
-Defined in: [error/index.d.ts:22](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L22)
+Defined in: [error/index.d.ts:22](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L22)
 
 A URI reference identifying the error type.
 
@@ -99,7 +99,7 @@ A URI reference identifying the error type.
 
 > **add**(`errors`): `void`
 
-Defined in: [error/index.d.ts:36](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L36)
+Defined in: [error/index.d.ts:36](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L36)
 
 Adds one or more errors to the error aggregation.
 Converts raw `Error` instances to `ApplicationError` for consistency.
@@ -120,7 +120,7 @@ The errors to aggregate.
 
 > **add**(...`errors`): `void`
 
-Defined in: [error/index.d.ts:37](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L37)
+Defined in: [error/index.d.ts:37](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L37)
 
 ##### Parameters
 
@@ -138,7 +138,7 @@ Defined in: [error/index.d.ts:37](https://github.com/micrajs/micra/blob/de3b06bd
 
 > **clear**(): `void`
 
-Defined in: [error/index.d.ts:40](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L40)
+Defined in: [error/index.d.ts:40](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L40)
 
 Clears all aggregated errors.
 
@@ -152,7 +152,7 @@ Clears all aggregated errors.
 
 > **toJSON**(`options`?): [`SerializedError`](SerializedError.md)
 
-Defined in: [error/index.d.ts:48](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L48)
+Defined in: [error/index.d.ts:48](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L48)
 
 Serializes the error into a structured JSON format.
 

--- a/packages/core/docs/references/namespaces/Micra/interfaces/ErrorDetail.md
+++ b/packages/core/docs/references/namespaces/Micra/interfaces/ErrorDetail.md
@@ -6,7 +6,7 @@
 
 # Interface: ErrorDetail
 
-Defined in: [error/index.d.ts:66](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L66)
+Defined in: [error/index.d.ts:66](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L66)
 
 Represents the core structure of an error message.
 This ensures consistency and predictability in error reporting.
@@ -21,7 +21,7 @@ This ensures consistency and predictability in error reporting.
 
 > `optional` **detail**: `string`
 
-Defined in: [error/index.d.ts:96](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L96)
+Defined in: [error/index.d.ts:96](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L96)
 
 A human-readable explanation of the error.
 Gives more details on why the error occurred.
@@ -42,7 +42,7 @@ Gives more details on why the error occurred.
 
 > `optional` **instance**: `string`
 
-Defined in: [error/index.d.ts:105](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L105)
+Defined in: [error/index.d.ts:105](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L105)
 
 A URI reference identifying the specific instance of the error.
 Useful for providing a traceable reference to a failing request or resource.
@@ -63,7 +63,7 @@ Useful for providing a traceable reference to a failing request or resource.
 
 > `optional` **metadata**: `Record`\<`string`, `any`\>
 
-Defined in: [error/index.d.ts:123](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L123)
+Defined in: [error/index.d.ts:123](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L123)
 
 Additional metadata related to the error.
 Can be used to store extra context, such as validation fields or debug information.
@@ -84,7 +84,7 @@ Can be used to store extra context, such as validation fields or debug informati
 
 > **status**: `number`
 
-Defined in: [error/index.d.ts:77](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L77)
+Defined in: [error/index.d.ts:77](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L77)
 
 HTTP status code representing the error.
 Used to indicate the nature of the failure.
@@ -115,7 +115,7 @@ Used to indicate the nature of the failure.
 
 > **title**: `string`
 
-Defined in: [error/index.d.ts:87](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L87)
+Defined in: [error/index.d.ts:87](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L87)
 
 A short, human-readable title describing the error type.
 Should provide a clear summary of the error.
@@ -140,7 +140,7 @@ Should provide a clear summary of the error.
 
 > `optional` **type**: `string`
 
-Defined in: [error/index.d.ts:114](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L114)
+Defined in: [error/index.d.ts:114](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L114)
 
 A URI reference identifying the type of error.
 Can point to documentation or predefined problem types.

--- a/packages/core/docs/references/namespaces/Micra/interfaces/ErrorOptions.md
+++ b/packages/core/docs/references/namespaces/Micra/interfaces/ErrorOptions.md
@@ -6,7 +6,7 @@
 
 # Interface: ErrorOptions
 
-Defined in: [error/index.d.ts:141](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L141)
+Defined in: [error/index.d.ts:141](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L141)
 
 Defines the properties available when creating an `ApplicationError`.
 Allows partial definition of `ErrorDetail`, with a required `title`.
@@ -21,7 +21,7 @@ Allows partial definition of `ErrorDetail`, with a required `title`.
 
 > `optional` **detail**: `string`
 
-Defined in: [error/index.d.ts:96](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L96)
+Defined in: [error/index.d.ts:96](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L96)
 
 A human-readable explanation of the error.
 Gives more details on why the error occurred.
@@ -46,7 +46,7 @@ Gives more details on why the error occurred.
 
 > `optional` **instance**: `string`
 
-Defined in: [error/index.d.ts:105](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L105)
+Defined in: [error/index.d.ts:105](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L105)
 
 A URI reference identifying the specific instance of the error.
 Useful for providing a traceable reference to a failing request or resource.
@@ -71,7 +71,7 @@ Useful for providing a traceable reference to a failing request or resource.
 
 > `optional` **metadata**: `Record`\<`string`, `any`\>
 
-Defined in: [error/index.d.ts:123](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L123)
+Defined in: [error/index.d.ts:123](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L123)
 
 Additional metadata related to the error.
 Can be used to store extra context, such as validation fields or debug information.
@@ -96,7 +96,7 @@ Can be used to store extra context, such as validation fields or debug informati
 
 > `optional` **status**: `number`
 
-Defined in: [error/index.d.ts:77](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L77)
+Defined in: [error/index.d.ts:77](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L77)
 
 HTTP status code representing the error.
 Used to indicate the nature of the failure.
@@ -131,7 +131,7 @@ Used to indicate the nature of the failure.
 
 > **title**: `string`
 
-Defined in: [error/index.d.ts:143](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L143)
+Defined in: [error/index.d.ts:143](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L143)
 
 A short, human-readable title describing the error type.
 
@@ -145,7 +145,7 @@ A short, human-readable title describing the error type.
 
 > `optional` **type**: `string`
 
-Defined in: [error/index.d.ts:114](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L114)
+Defined in: [error/index.d.ts:114](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L114)
 
 A URI reference identifying the type of error.
 Can point to documentation or predefined problem types.

--- a/packages/core/docs/references/namespaces/Micra/interfaces/ErrorSerializerOptions.md
+++ b/packages/core/docs/references/namespaces/Micra/interfaces/ErrorSerializerOptions.md
@@ -6,7 +6,7 @@
 
 # Interface: ErrorSerializerOptions
 
-Defined in: [error/index.d.ts:54](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L54)
+Defined in: [error/index.d.ts:54](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L54)
 
 Defines options for serializing an error.
 
@@ -16,7 +16,7 @@ Defines options for serializing an error.
 
 > `optional` **depth**: `number`
 
-Defined in: [error/index.d.ts:59](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L59)
+Defined in: [error/index.d.ts:59](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L59)
 
 The maximum depth for serializing nested errors to prevent infinite recursion.
 
@@ -26,6 +26,6 @@ The maximum depth for serializing nested errors to prevent infinite recursion.
 
 > `optional` **includeStack**: `boolean`
 
-Defined in: [error/index.d.ts:56](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L56)
+Defined in: [error/index.d.ts:56](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L56)
 
 Whether to include the stack trace in serialization output.

--- a/packages/core/docs/references/namespaces/Micra/interfaces/Event.md
+++ b/packages/core/docs/references/namespaces/Micra/interfaces/Event.md
@@ -1,0 +1,187 @@
+[**@micra/core**](../../../README.md)
+
+***
+
+[@micra/core](../../../README.md) / [Micra](../README.md) / Event
+
+# Interface: Event\<Type, Detail\>
+
+Defined in: [event-emitter/index.d.ts:9](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/event-emitter/index.d.ts#L9)
+
+Represents an event object with metadata, propagation controls, and a composed path.
+
+## Type Parameters
+
+• **Type** *extends* `string` \| `number` \| `symbol` = `string`
+
+The event type identifier (string, number, or symbol).
+
+• **Detail** *extends* `Record`\<`any`, `any`\> = \{\}
+
+The structured metadata associated with the event.
+
+## Properties
+
+### bubbles
+
+> `readonly` **bubbles**: `boolean`
+
+Defined in: [event-emitter/index.d.ts:31](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/event-emitter/index.d.ts#L31)
+
+Indicates whether the event bubbles up through the event chain.
+
+***
+
+### cancelable
+
+> `readonly` **cancelable**: `boolean`
+
+Defined in: [event-emitter/index.d.ts:36](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/event-emitter/index.d.ts#L36)
+
+Indicates whether the event can be canceled using `preventDefault()`.
+
+***
+
+### currentTarget
+
+> `readonly` **currentTarget**: [`EventEmitter`](EventEmitter.md)\<`Record`\<`string`, `any`\>\>
+
+Defined in: [event-emitter/index.d.ts:46](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/event-emitter/index.d.ts#L46)
+
+The `EventEmitter` currently processing the event.
+
+***
+
+### defaultPrevented
+
+> `readonly` **defaultPrevented**: `boolean`
+
+Defined in: [event-emitter/index.d.ts:41](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/event-emitter/index.d.ts#L41)
+
+Indicates whether `preventDefault()` was called on the event.
+
+***
+
+### detail
+
+> `readonly` **detail**: `Detail`
+
+Defined in: [event-emitter/index.d.ts:21](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/event-emitter/index.d.ts#L21)
+
+Additional data related to the event, providing context for event handlers.
+
+***
+
+### eventPhase
+
+> `readonly` **eventPhase**: `number`
+
+Defined in: [event-emitter/index.d.ts:26](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/event-emitter/index.d.ts#L26)
+
+The current phase of the event (e.g., capturing, at target, or bubbling).
+
+***
+
+### immediatePropagationStopped
+
+> `readonly` **immediatePropagationStopped**: `boolean`
+
+Defined in: [event-emitter/index.d.ts:61](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/event-emitter/index.d.ts#L61)
+
+Indicates whether `stopImmediatePropagation()` was called on the event.
+
+***
+
+### propagationStopped
+
+> `readonly` **propagationStopped**: `boolean`
+
+Defined in: [event-emitter/index.d.ts:66](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/event-emitter/index.d.ts#L66)
+
+Indicates whether `stopPropagation()` was called, halting the event’s propagation.
+
+***
+
+### target
+
+> `readonly` **target**: [`EventEmitter`](EventEmitter.md)\<`Record`\<`string`, `any`\>\>
+
+Defined in: [event-emitter/index.d.ts:51](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/event-emitter/index.d.ts#L51)
+
+The original `EventEmitter` that dispatched the event.
+
+***
+
+### timeStamp
+
+> `readonly` **timeStamp**: `number`
+
+Defined in: [event-emitter/index.d.ts:56](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/event-emitter/index.d.ts#L56)
+
+The time when the event was created, in milliseconds.
+
+***
+
+### type
+
+> `readonly` **type**: `Type`
+
+Defined in: [event-emitter/index.d.ts:16](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/event-emitter/index.d.ts#L16)
+
+The type of the event, indicating the specific event that occurred.
+
+## Methods
+
+### composedPath()
+
+> **composedPath**(): [`EventEmitter`](EventEmitter.md)\<`Record`\<`string`, `any`\>\>[]
+
+Defined in: [event-emitter/index.d.ts:86](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/event-emitter/index.d.ts#L86)
+
+Returns an array representing the path the event follows through the event emitters.
+
+#### Returns
+
+[`EventEmitter`](EventEmitter.md)\<`Record`\<`string`, `any`\>\>[]
+
+***
+
+### preventDefault()
+
+> **preventDefault**(): `void`
+
+Defined in: [event-emitter/index.d.ts:81](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/event-emitter/index.d.ts#L81)
+
+Cancels the event’s default action if it is cancelable.
+
+#### Returns
+
+`void`
+
+***
+
+### stopImmediatePropagation()
+
+> **stopImmediatePropagation**(): `void`
+
+Defined in: [event-emitter/index.d.ts:76](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/event-emitter/index.d.ts#L76)
+
+Stops the event from propagating and prevents other listeners on the same event from being executed.
+
+#### Returns
+
+`void`
+
+***
+
+### stopPropagation()
+
+> **stopPropagation**(): `void`
+
+Defined in: [event-emitter/index.d.ts:71](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/event-emitter/index.d.ts#L71)
+
+Prevents the event from propagating further in the event chain.
+
+#### Returns
+
+`void`

--- a/packages/core/docs/references/namespaces/Micra/interfaces/EventEmitter.md
+++ b/packages/core/docs/references/namespaces/Micra/interfaces/EventEmitter.md
@@ -1,0 +1,106 @@
+[**@micra/core**](../../../README.md)
+
+***
+
+[@micra/core](../../../README.md) / [Micra](../README.md) / EventEmitter
+
+# Interface: EventEmitter\<EventMap\>
+
+Defined in: [event-emitter/index.d.ts:133](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/event-emitter/index.d.ts#L133)
+
+Defines an event emitter with methods to add, remove, and dispatch events.
+
+## Type Parameters
+
+• **EventMap** *extends* `Record`\<`string`, `any`\> = `Record`\<`string`, `any`\>
+
+A record that maps event types to their corresponding detail objects.
+
+## Methods
+
+### addEventListener()
+
+> **addEventListener**\<`Type`\>(`type`, `listener`, `options`?): () => `void`
+
+Defined in: [event-emitter/index.d.ts:138](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/event-emitter/index.d.ts#L138)
+
+Adds an event listener for a specific event type, with support for glob patterns and optional listener settings.
+Returns a function that removes the added listener when called.
+
+#### Type Parameters
+
+• **Type** *extends* `string`
+
+#### Parameters
+
+##### type
+
+`Type`
+
+##### listener
+
+[`EventListener`](EventListener.md)\<[`MatchGlobEvents`](../type-aliases/MatchGlobEvents.md)\<`Type`, `EventMap`\>\>
+
+##### options?
+
+`boolean` | [`AddEventListenerOptions`](AddEventListenerOptions.md)
+
+#### Returns
+
+`Function`
+
+##### Returns
+
+`void`
+
+***
+
+### dispatchEvent()
+
+> **dispatchEvent**\<`Type`\>(`event`): `boolean`
+
+Defined in: [event-emitter/index.d.ts:155](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/event-emitter/index.d.ts#L155)
+
+Dispatches an event to all registered listeners, returning a boolean indicating if any listener called `preventDefault()`.
+
+#### Type Parameters
+
+• **Type** *extends* `string` \| `number` \| `symbol`
+
+#### Parameters
+
+##### event
+
+[`Event`](Event.md)\<`Type`, `EventMap`\[`Type`\]\>
+
+#### Returns
+
+`boolean`
+
+***
+
+### removeEventListener()
+
+> **removeEventListener**\<`Type`\>(`type`, `listener`): `void`
+
+Defined in: [event-emitter/index.d.ts:147](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/event-emitter/index.d.ts#L147)
+
+Removes a previously added event listener for a specific event type.
+
+#### Type Parameters
+
+• **Type** *extends* `string`
+
+#### Parameters
+
+##### type
+
+`Type`
+
+##### listener
+
+[`EventListener`](EventListener.md)\<[`MatchGlobEvents`](../type-aliases/MatchGlobEvents.md)\<`Type`, `EventMap`\>\>
+
+#### Returns
+
+`void`

--- a/packages/core/docs/references/namespaces/Micra/interfaces/EventListener.md
+++ b/packages/core/docs/references/namespaces/Micra/interfaces/EventListener.md
@@ -1,0 +1,33 @@
+[**@micra/core**](../../../README.md)
+
+***
+
+[@micra/core](../../../README.md) / [Micra](../README.md) / EventListener
+
+# Interface: EventListener()\<E\>
+
+Defined in: [event-emitter/index.d.ts:114](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/event-emitter/index.d.ts#L114)
+
+A type for event listener functions that handle dispatched events.
+
+## Type Parameters
+
+• **E** *extends* [`Event`](Event.md)\<`any`, `any`\> = [`Event`](Event.md)\<`any`, `any`\>
+
+The event object type, ensuring type safety.
+
+> **EventListener**(`event`): `void`
+
+Defined in: [event-emitter/index.d.ts:115](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/event-emitter/index.d.ts#L115)
+
+A type for event listener functions that handle dispatched events.
+
+## Parameters
+
+### event
+
+`E`
+
+## Returns
+
+`void`

--- a/packages/core/docs/references/namespaces/Micra/interfaces/SerializedError.md
+++ b/packages/core/docs/references/namespaces/Micra/interfaces/SerializedError.md
@@ -6,7 +6,7 @@
 
 # Interface: SerializedError
 
-Defined in: [error/index.d.ts:129](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L129)
+Defined in: [error/index.d.ts:129](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L129)
 
 Represents a serialized version of an error, including stack trace and nested errors.
 
@@ -20,7 +20,7 @@ Represents a serialized version of an error, including stack trace and nested er
 
 > `optional` **detail**: `string`
 
-Defined in: [error/index.d.ts:96](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L96)
+Defined in: [error/index.d.ts:96](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L96)
 
 A human-readable explanation of the error.
 Gives more details on why the error occurred.
@@ -45,7 +45,7 @@ Gives more details on why the error occurred.
 
 > `optional` **errors**: [`SerializedError`](SerializedError.md)[]
 
-Defined in: [error/index.d.ts:134](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L134)
+Defined in: [error/index.d.ts:134](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L134)
 
 Serialized representation of nested errors.
 
@@ -55,7 +55,7 @@ Serialized representation of nested errors.
 
 > `optional` **instance**: `string`
 
-Defined in: [error/index.d.ts:105](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L105)
+Defined in: [error/index.d.ts:105](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L105)
 
 A URI reference identifying the specific instance of the error.
 Useful for providing a traceable reference to a failing request or resource.
@@ -80,7 +80,7 @@ Useful for providing a traceable reference to a failing request or resource.
 
 > `optional` **metadata**: `Record`\<`string`, `any`\>
 
-Defined in: [error/index.d.ts:123](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L123)
+Defined in: [error/index.d.ts:123](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L123)
 
 Additional metadata related to the error.
 Can be used to store extra context, such as validation fields or debug information.
@@ -105,7 +105,7 @@ Can be used to store extra context, such as validation fields or debug informati
 
 > `optional` **stack**: `string`
 
-Defined in: [error/index.d.ts:131](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L131)
+Defined in: [error/index.d.ts:131](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L131)
 
 Stack trace of the error, if available.
 
@@ -115,7 +115,7 @@ Stack trace of the error, if available.
 
 > **status**: `number`
 
-Defined in: [error/index.d.ts:77](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L77)
+Defined in: [error/index.d.ts:77](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L77)
 
 HTTP status code representing the error.
 Used to indicate the nature of the failure.
@@ -150,7 +150,7 @@ Used to indicate the nature of the failure.
 
 > **title**: `string`
 
-Defined in: [error/index.d.ts:87](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L87)
+Defined in: [error/index.d.ts:87](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L87)
 
 A short, human-readable title describing the error type.
 Should provide a clear summary of the error.
@@ -179,7 +179,7 @@ Should provide a clear summary of the error.
 
 > `optional` **type**: `string`
 
-Defined in: [error/index.d.ts:114](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/core/error/index.d.ts#L114)
+Defined in: [error/index.d.ts:114](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/error/index.d.ts#L114)
 
 A URI reference identifying the type of error.
 Can point to documentation or predefined problem types.

--- a/packages/core/docs/references/namespaces/Micra/type-aliases/MatchGlobEvents.md
+++ b/packages/core/docs/references/namespaces/Micra/type-aliases/MatchGlobEvents.md
@@ -1,0 +1,23 @@
+[**@micra/core**](../../../README.md)
+
+***
+
+[@micra/core](../../../README.md) / [Micra](../README.md) / MatchGlobEvents
+
+# Type Alias: MatchGlobEvents\<Glob, EventMap\>
+
+> **MatchGlobEvents**\<`Glob`, `EventMap`\>: `{ [K in keyof EventMap]: K extends GlobToPath<Glob> ? Event<K, EventMap[K]> : never }`\[keyof `EventMap`\]
+
+Defined in: [event-emitter/index.d.ts:124](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/core/event-emitter/index.d.ts#L124)
+
+Matches all events in a given event map against a glob pattern.
+
+## Type Parameters
+
+• **Glob** *extends* `string`
+
+The glob pattern string to match event types.
+
+• **EventMap** *extends* `Record`\<`string`, `any`\>
+
+A record mapping event types to their corresponding detail objects.

--- a/packages/error/docs/references/index/classes/ApplicationError.md
+++ b/packages/error/docs/references/index/classes/ApplicationError.md
@@ -6,7 +6,7 @@
 
 # Class: ApplicationError
 
-Defined in: [classes/ApplicationError.ts:9](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/error/src/classes/ApplicationError.ts#L9)
+Defined in: [classes/ApplicationError.ts:9](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/error/src/classes/ApplicationError.ts#L9)
 
 Represents a structured error in the application. Supports metadata, nested error aggregation, and serialization.
 
@@ -24,7 +24,7 @@ Represents a structured error in the application. Supports metadata, nested erro
 
 > **new ApplicationError**(`messageOrDetails`): [`ApplicationError`](ApplicationError.md)
 
-Defined in: [classes/ApplicationError.ts:43](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/error/src/classes/ApplicationError.ts#L43)
+Defined in: [classes/ApplicationError.ts:43](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/error/src/classes/ApplicationError.ts#L43)
 
 Creates a new instance of ApplicationError.
 
@@ -66,7 +66,7 @@ throw new ApplicationError({
 
 > `optional` **detail**: `string`
 
-Defined in: [classes/ApplicationError.ts:10](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/error/src/classes/ApplicationError.ts#L10)
+Defined in: [classes/ApplicationError.ts:10](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/error/src/classes/ApplicationError.ts#L10)
 
 A human-readable explanation of the error.
 
@@ -80,7 +80,7 @@ A human-readable explanation of the error.
 
 > **errors**: `ApplicationError`[] = `[]`
 
-Defined in: [classes/ApplicationError.ts:16](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/error/src/classes/ApplicationError.ts#L16)
+Defined in: [classes/ApplicationError.ts:16](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/error/src/classes/ApplicationError.ts#L16)
 
 A collection of nested errors related to this error.
 
@@ -94,7 +94,7 @@ A collection of nested errors related to this error.
 
 > `optional` **instance**: `string`
 
-Defined in: [classes/ApplicationError.ts:11](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/error/src/classes/ApplicationError.ts#L11)
+Defined in: [classes/ApplicationError.ts:11](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/error/src/classes/ApplicationError.ts#L11)
 
 A URI reference identifying the specific instance of the error.
 
@@ -108,7 +108,7 @@ A URI reference identifying the specific instance of the error.
 
 > `optional` **metadata**: `Record`\<`string`, `any`\>
 
-Defined in: [classes/ApplicationError.ts:12](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/error/src/classes/ApplicationError.ts#L12)
+Defined in: [classes/ApplicationError.ts:12](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/error/src/classes/ApplicationError.ts#L12)
 
 Additional metadata related to the error.
 
@@ -122,7 +122,7 @@ Additional metadata related to the error.
 
 > **status**: `number`
 
-Defined in: [classes/ApplicationError.ts:13](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/error/src/classes/ApplicationError.ts#L13)
+Defined in: [classes/ApplicationError.ts:13](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/error/src/classes/ApplicationError.ts#L13)
 
 HTTP status code associated with the error.
 
@@ -136,7 +136,7 @@ HTTP status code associated with the error.
 
 > **title**: `string`
 
-Defined in: [classes/ApplicationError.ts:14](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/error/src/classes/ApplicationError.ts#L14)
+Defined in: [classes/ApplicationError.ts:14](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/error/src/classes/ApplicationError.ts#L14)
 
 A short, human-readable title describing the error type.
 
@@ -150,7 +150,7 @@ A short, human-readable title describing the error type.
 
 > `optional` **type**: `string`
 
-Defined in: [classes/ApplicationError.ts:15](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/error/src/classes/ApplicationError.ts#L15)
+Defined in: [classes/ApplicationError.ts:15](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/error/src/classes/ApplicationError.ts#L15)
 
 A URI reference identifying the error type.
 
@@ -166,7 +166,7 @@ A URI reference identifying the error type.
 
 > **get** **hasErrors**(): `boolean`
 
-Defined in: [classes/ApplicationError.ts:20](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/error/src/classes/ApplicationError.ts#L20)
+Defined in: [classes/ApplicationError.ts:20](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/error/src/classes/ApplicationError.ts#L20)
 
 Indicates whether there are any aggregated errors.
 
@@ -184,7 +184,7 @@ Indicates whether there are any aggregated errors.
 
 > **add**(`maybeList`?, ...`rest`?): `void`
 
-Defined in: [classes/ApplicationError.ts:61](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/error/src/classes/ApplicationError.ts#L61)
+Defined in: [classes/ApplicationError.ts:60](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/error/src/classes/ApplicationError.ts#L60)
 
 Adds one or more errors to the error aggregation.
 Converts raw `Error` instances to `ApplicationError` for consistency.
@@ -213,7 +213,7 @@ Converts raw `Error` instances to `ApplicationError` for consistency.
 
 > **clear**(): `void`
 
-Defined in: [classes/ApplicationError.ts:67](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/error/src/classes/ApplicationError.ts#L67)
+Defined in: [classes/ApplicationError.ts:66](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/error/src/classes/ApplicationError.ts#L66)
 
 Clears all aggregated errors.
 
@@ -231,7 +231,7 @@ Clears all aggregated errors.
 
 > **toJSON**(`options`): `SerializedError`
 
-Defined in: [classes/ApplicationError.ts:71](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/error/src/classes/ApplicationError.ts#L71)
+Defined in: [classes/ApplicationError.ts:70](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/error/src/classes/ApplicationError.ts#L70)
 
 Serializes the error into a structured JSON format.
 

--- a/packages/error/docs/references/index/functions/isApplicationError.md
+++ b/packages/error/docs/references/index/functions/isApplicationError.md
@@ -8,7 +8,7 @@
 
 > **isApplicationError**(`maybeError`): `maybeError is ApplicationError`
 
-Defined in: [guards/isApplicationError.ts:19](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/error/src/guards/isApplicationError.ts#L19)
+Defined in: [guards/isApplicationError.ts:19](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/error/src/guards/isApplicationError.ts#L19)
 
 Checks if the given value is an `Micra.ApplicationError`.
 This function verifies that the object adheres to the `Micra.ApplicationError` interface.

--- a/packages/error/docs/references/index/functions/isError.md
+++ b/packages/error/docs/references/index/functions/isError.md
@@ -8,7 +8,7 @@
 
 > **isError**(`maybeError`): `maybeError is Error`
 
-Defined in: [guards/isError.ts:16](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/error/src/guards/isError.ts#L16)
+Defined in: [guards/isError.ts:16](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/error/src/guards/isError.ts#L16)
 
 Checks if the given value is a standard `Error` object.
 This function ensures that the object contains the essential properties of an `Error`.

--- a/packages/error/docs/references/index/functions/isErrorOptions.md
+++ b/packages/error/docs/references/index/functions/isErrorOptions.md
@@ -8,7 +8,7 @@
 
 > **isErrorOptions**(`maybeOptions`): `maybeOptions is ErrorOptions`
 
-Defined in: [guards/isErrorOptions.ts:16](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/error/src/guards/isErrorOptions.ts#L16)
+Defined in: [guards/isErrorOptions.ts:16](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/error/src/guards/isErrorOptions.ts#L16)
 
 Checks if the given value is a valid `Micra.ErrorOptions` object.
 Validates that the object matches the structure expected for `Micra.ErrorOptions`.

--- a/packages/error/docs/references/index/functions/normalizeError.md
+++ b/packages/error/docs/references/index/functions/normalizeError.md
@@ -8,7 +8,7 @@
 
 > **normalizeError**(`value`): `ApplicationError`
 
-Defined in: [utilities/normalizeError.ts:22](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/error/src/utilities/normalizeError.ts#L22)
+Defined in: [utilities/normalizeError.ts:22](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/error/src/utilities/normalizeError.ts#L22)
 
 Converts a given value into an `ApplicationError`.
 If the value is already an `ApplicationError`, it is returned as-is.

--- a/packages/event-emitter/docs/how-to/Add and Remove Event Listeners.md
+++ b/packages/event-emitter/docs/how-to/Add and Remove Event Listeners.md
@@ -15,7 +15,7 @@ The `EventEmitter` class in `@micra/event-emitter` provides a robust system for 
 Before using event listeners, you need to import and instantiate an `EventEmitter`.
 
 ```ts
-import {EventEmitter} from '@micra/event-emitter';
+import {EventEmitter} from '@micra/event-emitter/EventEmitter';
 
 const emitter = new EventEmitter();
 ```

--- a/packages/event-emitter/docs/how-to/Add and Remove Event Listeners.md
+++ b/packages/event-emitter/docs/how-to/Add and Remove Event Listeners.md
@@ -1,0 +1,60 @@
+# Add and Remove Event Listeners
+
+## Goal
+
+This guide will show you how to register and remove event listeners using the `@micra/event-emitter` package. Event listeners allow you to execute functions when specific events occur, making event-driven programming more modular and maintainable.
+
+## Context
+
+The `EventEmitter` class in `@micra/event-emitter` provides a robust system for managing events. It allows you to register event listeners, trigger events, and remove listeners when they are no longer needed. Properly managing event listeners prevents memory leaks and ensures efficient event handling.
+
+## Steps
+
+### Step 1: Import `EventEmitter`
+
+Before using event listeners, you need to import and instantiate an `EventEmitter`.
+
+```ts
+import {EventEmitter} from '@micra/event-emitter';
+
+const emitter = new EventEmitter();
+```
+
+### Step 2: Register an Event Listener
+
+To listen for an event, use `addEventListener`. This method accepts an event type and a callback function.
+
+```ts
+const onUserLogin = (event) => {
+  console.log(`User logged in:`, event.detail);
+};
+
+const unsubscribe = emitter.addEventListener('user.login', onUserLogin);
+```
+
+### Step 3: Remove an Event Listener
+
+There are two ways to remove an event listener:
+
+#### Using `removeEventListener`
+
+```ts
+emitter.removeEventListener('user.login', onUserLogin);
+```
+
+#### Using the Unsubscribe Callback
+
+When adding a listener, `addEventListener` returns a function that removes the listener when called.
+
+```ts
+unsubscribe();
+```
+
+## Verification
+
+To verify that event listeners are working correctly:
+
+- Add a listener and dispatch an event to see if the callback executes.
+- Remove the listener and dispatch the event again to confirm that it no longer executes.
+
+This guide ensures proper event listener management, helping maintain an efficient and scalable event-driven system.

--- a/packages/event-emitter/docs/how-to/Handle Event Propagation and Bubbling.md
+++ b/packages/event-emitter/docs/how-to/Handle Event Propagation and Bubbling.md
@@ -1,0 +1,77 @@
+# Handle Event Propagation and Bubbling
+
+## Goal
+
+This guide will show you how to control event flow across different event emitters in a hierarchy using the `@micra/event-emitter` package. Understanding event propagation and bubbling allows for more effective event handling in complex applications.
+
+## Context
+
+The `EventEmitter` class in `@micra/event-emitter` supports event propagation and bubbling, enabling events to travel through a hierarchy of emitters. This mechanism is particularly useful for designing modular, decoupled systems where events can be handled at different levels in the application.
+
+## Steps
+
+### Step 1: Import `EventEmitter`
+
+Before handling event propagation, import and instantiate `EventEmitter` instances representing different levels in a hierarchy.
+
+```ts
+import {EventEmitter} from '@micra/event-emitter/EventEmitter';
+
+const parentEmitter = new EventEmitter();
+const childEmitter = new EventEmitter();
+```
+
+### Step 2: Establish a Hierarchical Relationship
+
+For events to bubble, child emitters need to be linked to a parent.
+
+```ts
+parentEmitter.reparent(childEmitter);
+```
+
+### Step 3: Register Listeners at Different Levels
+
+Listeners can be added to both parent and child emitters.
+
+```ts
+parentEmitter.addEventListener('user.updated', (event) => {
+  console.log('Parent received event:', event.detail);
+});
+
+childEmitter.addEventListener('user.updated', (event) => {
+  console.log('Child received event:', event.detail);
+});
+```
+
+### Step 4: Dispatch Events and Observe Bubbling
+
+When an event is dispatched from the child emitter, it propagates to the parent if bubbling is enabled.
+
+```ts
+import {Event} from '@micra/event-emitter/Event';
+
+childEmitter.dispatchEvent(
+  new Event('user.updated', {detail: {userId: 42}, bubbles: true}),
+);
+```
+
+### Step 5: Stop Event Propagation
+
+If an event should not propagate further up the hierarchy, use `stopPropagation()`.
+
+```ts
+childEmitter.addEventListener('user.updated', (event) => {
+  event.stopPropagation();
+  console.log('Child stopped propagation');
+});
+```
+
+## Verification
+
+To verify event propagation and bubbling:
+
+- Dispatch an event from a child emitter and observe if it reaches the parent.
+- Use `stopPropagation()` in the child listener and confirm that the parent does not receive the event.
+- Ensure bubbling is enabled when necessary and disabled where required.
+
+This guide ensures developers can effectively manage event flow within hierarchical structures, making event-driven applications more flexible and scalable.

--- a/packages/event-emitter/docs/how-to/Use Wildcard Listeners for Event Filtering.md
+++ b/packages/event-emitter/docs/how-to/Use Wildcard Listeners for Event Filtering.md
@@ -1,0 +1,85 @@
+# Use Wildcard Listeners for Event Filtering
+
+## Goal
+
+This guide will show you how to use wildcard event names to listen for multiple event types dynamically in the `@micra/event-emitter` package. Wildcard listeners simplify event handling by allowing a single listener to match multiple related events.
+
+## Context
+
+The `EventEmitter` class in `@micra/event-emitter` supports wildcard event names, making it easier to listen for related event patterns without explicitly registering each event type. This is particularly useful for handling dynamic event names, namespaced events, or grouped event types.
+
+## Steps
+
+### Step 1: Import `EventEmitter`
+
+Before using wildcard listeners, import and instantiate an `EventEmitter`.
+
+```ts
+import {EventEmitter} from '@micra/event-emitter/EventEmitter';
+
+const emitter = new EventEmitter();
+```
+
+### Step 2: Register a Wildcard Listener
+
+Wildcard listeners use patterns such as `*` to match multiple event types.
+
+#### Listening to Events with a Single-Level Wildcard
+
+The `*` wildcard matches any event at a specific level.
+
+```ts
+emitter.addEventListener('user.*', (event) => {
+  console.log(`Wildcard matched: ${event.type}`, event.detail);
+});
+```
+
+In this example, the listener will match any event starting with `user.`, such as `user.created`, `user.deleted`, or `user.updated`.
+
+#### Listening to All Events with a Catch-All Wildcard
+
+The `*` wildcard listens for **all** events, regardless of type.
+
+```ts
+emitter.addEventListener('*', (event) => {
+  console.log(`Catch-all listener received: ${event.type}`, event.detail);
+});
+```
+
+This is useful for logging or debugging all emitted events.
+
+### Step 3: Dispatch Events
+
+When events are dispatched, wildcard listeners will automatically capture matching event types.
+
+```ts
+import {Event} from '@micra/event-emitter/Event';
+
+emitter.dispatchEvent(new Event('user.created', {detail: {userId: 42}}));
+emitter.dispatchEvent(new Event('user.deleted', {detail: {userId: 24}}));
+```
+
+The wildcard listener for `user.*` will trigger for both events, and the `**` listener will trigger for all events.
+
+### Step 4: Remove a Wildcard Listener
+
+Wildcard listeners can be removed the same way as regular listeners.
+
+```ts
+const unsubscribe = emitter.addEventListener('user.*', (event) => {
+  console.log(`User event received: ${event.type}`);
+});
+
+unsubscribe(); // Removes the wildcard listener
+```
+
+## Verification
+
+To verify wildcard listeners are working correctly:
+
+- Register a listener using a wildcard pattern.
+- Dispatch multiple events matching the wildcard pattern.
+- Observe that the listener captures all relevant events.
+- Remove the listener and confirm it no longer triggers.
+
+This guide ensures efficient event handling by using wildcard listeners, reducing redundant event registrations and improving maintainability in event-driven applications.

--- a/packages/event-emitter/docs/references/Event/README.md
+++ b/packages/event-emitter/docs/references/Event/README.md
@@ -1,0 +1,11 @@
+[**@micra/event-emitter**](../README.md)
+
+***
+
+[@micra/event-emitter](../README.md) / Event
+
+# Event
+
+## Classes
+
+- [Event](classes/Event.md)

--- a/packages/event-emitter/docs/references/Event/classes/Event.md
+++ b/packages/event-emitter/docs/references/Event/classes/Event.md
@@ -1,0 +1,311 @@
+[**@micra/event-emitter**](../../README.md)
+
+***
+
+[@micra/event-emitter](../../README.md) / [Event](../README.md) / Event
+
+# Class: Event\<Type, Detail\>
+
+Defined in: [classes/Event.ts:10](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/event-emitter/src/classes/Event.ts#L10)
+
+## Type Parameters
+
+• **Type** *extends* `string` \| `number` \| `symbol` = `string`
+
+• **Detail** *extends* `Record`\<`any`, `any`\> = \{\}
+
+## Implements
+
+- `Event`\<`Type`, `Detail`\>
+
+## Constructors
+
+### new Event()
+
+> **new Event**\<`Type`, `Detail`\>(`type`, `options`): [`Event`](Event.md)\<`Type`, `Detail`\>
+
+Defined in: [classes/Event.ts:46](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/event-emitter/src/classes/Event.ts#L46)
+
+#### Parameters
+
+##### type
+
+`Type`
+
+##### options
+
+`EventOptions`\<`Detail`\> = `{}`
+
+#### Returns
+
+[`Event`](Event.md)\<`Type`, `Detail`\>
+
+## Properties
+
+### bubbles
+
+> **bubbles**: `boolean`
+
+Defined in: [classes/Event.ts:22](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/event-emitter/src/classes/Event.ts#L22)
+
+Indicates whether the event bubbles up through the event chain.
+
+#### Implementation of
+
+`Micra.Event.bubbles`
+
+***
+
+### cancelable
+
+> **cancelable**: `boolean` = `false`
+
+Defined in: [classes/Event.ts:23](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/event-emitter/src/classes/Event.ts#L23)
+
+Indicates whether the event can be canceled using `preventDefault()`.
+
+#### Implementation of
+
+`Micra.Event.cancelable`
+
+***
+
+### defaultPrevented
+
+> **defaultPrevented**: `boolean` = `false`
+
+Defined in: [classes/Event.ts:24](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/event-emitter/src/classes/Event.ts#L24)
+
+Indicates whether `preventDefault()` was called on the event.
+
+#### Implementation of
+
+`Micra.Event.defaultPrevented`
+
+***
+
+### detail
+
+> **detail**: `Detail`
+
+Defined in: [classes/Event.ts:21](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/event-emitter/src/classes/Event.ts#L21)
+
+Additional data related to the event, providing context for event handlers.
+
+#### Implementation of
+
+`Micra.Event.detail`
+
+***
+
+### immediatePropagationStopped
+
+> **immediatePropagationStopped**: `boolean` = `false`
+
+Defined in: [classes/Event.ts:27](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/event-emitter/src/classes/Event.ts#L27)
+
+Indicates whether `stopImmediatePropagation()` was called on the event.
+
+#### Implementation of
+
+`Micra.Event.immediatePropagationStopped`
+
+***
+
+### propagationStopped
+
+> **propagationStopped**: `boolean` = `false`
+
+Defined in: [classes/Event.ts:28](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/event-emitter/src/classes/Event.ts#L28)
+
+Indicates whether `stopPropagation()` was called, halting the event’s propagation.
+
+#### Implementation of
+
+`Micra.Event.propagationStopped`
+
+***
+
+### target
+
+> **target**: `null` \| `EventEmitter`\<`any`\> = `null`
+
+Defined in: [classes/Event.ts:25](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/event-emitter/src/classes/Event.ts#L25)
+
+The original `EventEmitter` that dispatched the event.
+
+#### Implementation of
+
+`Micra.Event.target`
+
+***
+
+### timeStamp
+
+> **timeStamp**: `number`
+
+Defined in: [classes/Event.ts:26](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/event-emitter/src/classes/Event.ts#L26)
+
+The time when the event was created, in milliseconds.
+
+#### Implementation of
+
+`Micra.Event.timeStamp`
+
+***
+
+### type
+
+> **type**: `Type`
+
+Defined in: [classes/Event.ts:20](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/event-emitter/src/classes/Event.ts#L20)
+
+The type of the event, indicating the specific event that occurred.
+
+#### Implementation of
+
+`Micra.Event.type`
+
+***
+
+### AT\_TARGET
+
+> `static` **AT\_TARGET**: `number` = `2`
+
+Defined in: [classes/Event.ts:17](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/event-emitter/src/classes/Event.ts#L17)
+
+***
+
+### BUBBLING\_PHASE
+
+> `static` **BUBBLING\_PHASE**: `number` = `3`
+
+Defined in: [classes/Event.ts:18](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/event-emitter/src/classes/Event.ts#L18)
+
+***
+
+### CAPTURING\_PHASE
+
+> `static` **CAPTURING\_PHASE**: `number` = `1`
+
+Defined in: [classes/Event.ts:16](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/event-emitter/src/classes/Event.ts#L16)
+
+***
+
+### NONE
+
+> `static` **NONE**: `number` = `0`
+
+Defined in: [classes/Event.ts:15](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/event-emitter/src/classes/Event.ts#L15)
+
+## Accessors
+
+### currentTarget
+
+#### Get Signature
+
+> **get** **currentTarget**(): `null` \| `EventEmitter`\<`any`\>
+
+Defined in: [classes/Event.ts:38](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/event-emitter/src/classes/Event.ts#L38)
+
+The `EventEmitter` currently processing the event.
+
+##### Returns
+
+`null` \| `EventEmitter`\<`any`\>
+
+#### Implementation of
+
+`Micra.Event.currentTarget`
+
+***
+
+### eventPhase
+
+#### Get Signature
+
+> **get** **eventPhase**(): `number`
+
+Defined in: [classes/Event.ts:42](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/event-emitter/src/classes/Event.ts#L42)
+
+The current phase of the event (e.g., capturing, at target, or bubbling).
+
+##### Returns
+
+`number`
+
+#### Implementation of
+
+`Micra.Event.eventPhase`
+
+## Methods
+
+### composedPath()
+
+> **composedPath**(): `EventEmitter`\<`Record`\<`string`, `any`\>\>[]
+
+Defined in: [classes/Event.ts:69](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/event-emitter/src/classes/Event.ts#L69)
+
+Returns an array representing the path the event follows through the event emitters.
+
+#### Returns
+
+`EventEmitter`\<`Record`\<`string`, `any`\>\>[]
+
+#### Implementation of
+
+`Micra.Event.composedPath`
+
+***
+
+### preventDefault()
+
+> **preventDefault**(): `void`
+
+Defined in: [classes/Event.ts:63](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/event-emitter/src/classes/Event.ts#L63)
+
+Cancels the event’s default action if it is cancelable.
+
+#### Returns
+
+`void`
+
+#### Implementation of
+
+`Micra.Event.preventDefault`
+
+***
+
+### stopImmediatePropagation()
+
+> **stopImmediatePropagation**(): `void`
+
+Defined in: [classes/Event.ts:58](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/event-emitter/src/classes/Event.ts#L58)
+
+Stops the event from propagating and prevents other listeners on the same event from being executed.
+
+#### Returns
+
+`void`
+
+#### Implementation of
+
+`Micra.Event.stopImmediatePropagation`
+
+***
+
+### stopPropagation()
+
+> **stopPropagation**(): `void`
+
+Defined in: [classes/Event.ts:54](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/event-emitter/src/classes/Event.ts#L54)
+
+Prevents the event from propagating further in the event chain.
+
+#### Returns
+
+`void`
+
+#### Implementation of
+
+`Micra.Event.stopPropagation`

--- a/packages/event-emitter/docs/references/EventEmitter/README.md
+++ b/packages/event-emitter/docs/references/EventEmitter/README.md
@@ -1,0 +1,11 @@
+[**@micra/event-emitter**](../README.md)
+
+***
+
+[@micra/event-emitter](../README.md) / EventEmitter
+
+# EventEmitter
+
+## Classes
+
+- [EventEmitter](classes/EventEmitter.md)

--- a/packages/event-emitter/docs/references/EventEmitter/classes/EventEmitter.md
+++ b/packages/event-emitter/docs/references/EventEmitter/classes/EventEmitter.md
@@ -1,0 +1,152 @@
+[**@micra/event-emitter**](../../README.md)
+
+***
+
+[@micra/event-emitter](../../README.md) / [EventEmitter](../README.md) / EventEmitter
+
+# Class: EventEmitter\<EventMap\>
+
+Defined in: [classes/EventEmitter.ts:15](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/event-emitter/src/classes/EventEmitter.ts#L15)
+
+## Type Parameters
+
+• **EventMap** *extends* `Record`\<`string`, `any`\> = `Record`\<`string`, `any`\>
+
+## Implements
+
+- `EventEmitter`\<`EventMap`\>
+
+## Constructors
+
+### new EventEmitter()
+
+> **new EventEmitter**\<`EventMap`\>(): [`EventEmitter`](EventEmitter.md)\<`EventMap`\>
+
+#### Returns
+
+[`EventEmitter`](EventEmitter.md)\<`EventMap`\>
+
+## Methods
+
+### addEventListener()
+
+> **addEventListener**\<`Type`\>(`type`, `listener`, `options`): () => `void`
+
+Defined in: [classes/EventEmitter.ts:23](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/event-emitter/src/classes/EventEmitter.ts#L23)
+
+Adds an event listener for a specific event type, with support for glob patterns and optional listener settings.
+Returns a function that removes the added listener when called.
+
+#### Type Parameters
+
+• **Type** *extends* `string`
+
+#### Parameters
+
+##### type
+
+`Type`
+
+##### listener
+
+`EventListener`\<`MatchGlobEvents`\<`Type`, `EventMap`\>\>
+
+##### options
+
+`boolean` | `AddEventListenerOptions`
+
+#### Returns
+
+`Function`
+
+##### Returns
+
+`void`
+
+#### Implementation of
+
+`Micra.EventEmitter.addEventListener`
+
+***
+
+### dispatchEvent()
+
+> **dispatchEvent**\<`Type`\>(`event`): `boolean`
+
+Defined in: [classes/EventEmitter.ts:64](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/event-emitter/src/classes/EventEmitter.ts#L64)
+
+Dispatches an event to all registered listeners, returning a boolean indicating if any listener called `preventDefault()`.
+
+#### Type Parameters
+
+• **Type** *extends* `string` \| `number` \| `symbol`
+
+#### Parameters
+
+##### event
+
+[`Event`](../../Event/classes/Event.md)\<`Type`, `EventMap`\[`Type`\]\>
+
+#### Returns
+
+`boolean`
+
+#### Implementation of
+
+`Micra.EventEmitter.dispatchEvent`
+
+***
+
+### removeEventListener()
+
+> **removeEventListener**\<`Type`\>(`type`, `listener`): `void`
+
+Defined in: [classes/EventEmitter.ts:46](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/event-emitter/src/classes/EventEmitter.ts#L46)
+
+Removes a previously added event listener for a specific event type.
+
+#### Type Parameters
+
+• **Type** *extends* `string`
+
+#### Parameters
+
+##### type
+
+`Type`
+
+##### listener
+
+`EventListener`\<`MatchGlobEvents`\<`Type`, `EventMap`\>\>
+
+#### Returns
+
+`void`
+
+#### Implementation of
+
+`Micra.EventEmitter.removeEventListener`
+
+***
+
+### reparent()
+
+> **reparent**(`child`): `this`
+
+Defined in: [classes/EventEmitter.ts:137](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/event-emitter/src/classes/EventEmitter.ts#L137)
+
+Reparents a child event emitter to this event emitter. This will allow the child to bubble events up to this event emitter.
+
+#### Parameters
+
+##### child
+
+Child event emitter
+
+`EventEmitter`\<`any`\> | [`EventEmitter`](EventEmitter.md)\<`Record`\<`string`, `any`\>\>
+
+#### Returns
+
+`this`
+
+This event emitter.

--- a/packages/event-emitter/docs/references/README.md
+++ b/packages/event-emitter/docs/references/README.md
@@ -1,0 +1,11 @@
+**@micra/event-emitter**
+
+***
+
+# @micra/event-emitter
+
+## Modules
+
+- [Event](Event/README.md)
+- [EventEmitter](EventEmitter/README.md)
+- [index](index/README.md)

--- a/packages/event-emitter/docs/references/index/README.md
+++ b/packages/event-emitter/docs/references/index/README.md
@@ -1,0 +1,19 @@
+[**@micra/event-emitter**](../README.md)
+
+***
+
+[@micra/event-emitter](../README.md) / index
+
+# index
+
+## References
+
+### Event
+
+Re-exports [Event](../Event/classes/Event.md)
+
+***
+
+### EventEmitter
+
+Re-exports [EventEmitter](../EventEmitter/classes/EventEmitter.md)

--- a/packages/event-emitter/src/classes/Event.ts
+++ b/packages/event-emitter/src/classes/Event.ts
@@ -43,10 +43,8 @@ export class Event<
     return this[EVENT_PHASE];
   }
 
-  constructor(
-    type: Type,
-    {bubbles = true, cancelable = true, detail = {} as Detail}: EventOptions<Detail> = {},
-  ) {
+  constructor(type: Type, options: EventOptions<Detail> = {}) {
+    const {bubbles = true, cancelable = true, detail = {} as Detail} = options;
     this.bubbles = bubbles;
     this.cancelable = cancelable;
     this.detail = detail;

--- a/packages/event-emitter/src/classes/EventEmitter.test.ts
+++ b/packages/event-emitter/src/classes/EventEmitter.test.ts
@@ -7,7 +7,8 @@ describe('EventEmitter', () => {
   it('adds an event listener at capturing phase if options is true', () => {
     const listener = vi.fn();
     const root = new EventEmitter();
-    const child = new EventEmitter().reparent(root);
+    const child = new EventEmitter();
+    root.reparent(child);
 
     root.addEventListener('test', listener, true);
     child.dispatchEvent(new Event('test'));
@@ -39,8 +40,10 @@ describe('EventEmitter', () => {
     const listener = vi.fn();
     const event = new Event('test');
     const root = new EventEmitter();
-    const child = new EventEmitter().reparent(root);
-    const target = new EventEmitter().reparent(child);
+    const child = new EventEmitter();
+    const target = new EventEmitter();
+    root.reparent(child);
+    child.reparent(target);
     root.addEventListener('test', () => listener('root capturing'), {
       capture: true,
     });
@@ -69,8 +72,10 @@ describe('EventEmitter', () => {
     const listener = vi.fn();
     const event = new Event('test');
     const root = new EventEmitter();
-    const child = new EventEmitter().reparent(root);
-    const target = new EventEmitter().reparent(child);
+    const child = new EventEmitter();
+    const target = new EventEmitter();
+    root.reparent(child);
+    child.reparent(target);
     root.addEventListener('test', () => listener('root capturing'), {
       capture: true,
     });
@@ -136,8 +141,10 @@ describe('EventEmitter', () => {
   it('only calls target listeners for a non-bubbling event', () => {
     const listener = vi.fn();
     const root = new EventEmitter();
-    const child = new EventEmitter().reparent(root);
-    const target = new EventEmitter().reparent(child);
+    const child = new EventEmitter();
+    const target = new EventEmitter();
+    root.reparent(child);
+    child.reparent(target);
     const event = new Event('test', {bubbles: false});
     root.addEventListener('test', () => listener('root listener'), {
       capture: true,

--- a/packages/event-emitter/src/classes/EventEmitter.ts
+++ b/packages/event-emitter/src/classes/EventEmitter.ts
@@ -128,8 +128,14 @@ export class EventEmitter<EventMap extends Record<string, any> = Record<string, 
     return !event.defaultPrevented;
   }
 
-  reparent(parent: EventEmitter<any>): this {
-    this[EVENT_EMITTER_PARENT] = parent;
+  /**
+   * Reparents a child event emitter to this event emitter. This will allow the child to bubble events up to this event emitter.
+   *
+   * @param child Child event emitter
+   * @returns This event emitter.
+   */
+  reparent(child: Micra.EventEmitter<any> | EventEmitter): this {
+    (child as EventEmitter)[EVENT_EMITTER_PARENT] = this;
     return this;
   }
 

--- a/packages/utilities/docs/references/functions/isRecord.md
+++ b/packages/utilities/docs/references/functions/isRecord.md
@@ -8,7 +8,7 @@
 
 > **isRecord**(`maybeRecord`): `maybeRecord is Record<any, any>`
 
-Defined in: [isRecord.ts:15](https://github.com/micrajs/micra/blob/de3b06bdb3a3f670052250f7e0da7885aa7e590a/packages/utilities/src/isRecord.ts#L15)
+Defined in: [isRecord.ts:15](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/utilities/src/isRecord.ts#L15)
 
 Checks if the given value is a record (plain object) and not null, undefined, or an array.
 


### PR DESCRIPTION
> Closes #62 

### 📑 Summary

This pull request includes updates to the documentation, focusing mostly on the Event Emitter spec and implementation.

### Documentation Updates:

* [`packages/core/docs/references/namespaces/Micra/README.md`](diffhunk://#diff-9d4d96b2e9edb84c65a7d27b4ebec8fbe1504a0f539fefea430d00b267cb621cR32-R44): Added new interfaces `AddEventListenerOptions`, `Event`, `EventEmitter`, `EventListener`, and a new type alias `MatchGlobEvents`.
* [`packages/core/docs/references/namespaces/Micra/interfaces/AddEventListenerOptions.md`](diffhunk://#diff-19deeaa240d169866e51ab5a4d49d349ecf295e3e2fbf4fb16ad2f88ad597af6R1-R41): Added a new file documenting the `AddEventListenerOptions` interface, which defines options for event listeners.

### Reference Updates:

* [`packages/core/docs/references/namespaces/Micra/interfaces/ApplicationError.md`](diffhunk://#diff-eb31134c48f82e65a82f6a48349999f79166a7bdd8573ebc877d72b283e8174fL9-R9): Updated all references to the latest version of `error/index.d.ts`. [[1]](diffhunk://#diff-eb31134c48f82e65a82f6a48349999f79166a7bdd8573ebc877d72b283e8174fL9-R9) [[2]](diffhunk://#diff-eb31134c48f82e65a82f6a48349999f79166a7bdd8573ebc877d72b283e8174fL20-R20) [[3]](diffhunk://#diff-eb31134c48f82e65a82f6a48349999f79166a7bdd8573ebc877d72b283e8174fL30-R30) [[4]](diffhunk://#diff-eb31134c48f82e65a82f6a48349999f79166a7bdd8573ebc877d72b283e8174fL40-R40) [[5]](diffhunk://#diff-eb31134c48f82e65a82f6a48349999f79166a7bdd8573ebc877d72b283e8174fL50-R50) [[6]](diffhunk://#diff-eb31134c48f82e65a82f6a48349999f79166a7bdd8573ebc877d72b283e8174fL60-R60) [[7]](diffhunk://#diff-eb31134c48f82e65a82f6a48349999f79166a7bdd8573ebc877d72b283e8174fL70-R70) [[8]](diffhunk://#diff-eb31134c48f82e65a82f6a48349999f79166a7bdd8573ebc877d72b283e8174fL80-R80) [[9]](diffhunk://#diff-eb31134c48f82e65a82f6a48349999f79166a7bdd8573ebc877d72b283e8174fL90-R90) [[10]](diffhunk://#diff-eb31134c48f82e65a82f6a48349999f79166a7bdd8573ebc877d72b283e8174fL102-R102) [[11]](diffhunk://#diff-eb31134c48f82e65a82f6a48349999f79166a7bdd8573ebc877d72b283e8174fL123-R123) [[12]](diffhunk://#diff-eb31134c48f82e65a82f6a48349999f79166a7bdd8573ebc877d72b283e8174fL141-R141) [[13]](diffhunk://#diff-eb31134c48f82e65a82f6a48349999f79166a7bdd8573ebc877d72b283e8174fL155-R155)
* [`packages/core/docs/references/namespaces/Micra/interfaces/ErrorDetail.md`](diffhunk://#diff-4314e1f05838dcc2d6db65a96d22535d2e3fc02e66ee071885f15732001b7812L9-R9): Updated all references to the latest version of `error/index.d.ts`. [[1]](diffhunk://#diff-4314e1f05838dcc2d6db65a96d22535d2e3fc02e66ee071885f15732001b7812L9-R9) [[2]](diffhunk://#diff-4314e1f05838dcc2d6db65a96d22535d2e3fc02e66ee071885f15732001b7812L24-R24) [[3]](diffhunk://#diff-4314e1f05838dcc2d6db65a96d22535d2e3fc02e66ee071885f15732001b7812L45-R45) [[4]](diffhunk://#diff-4314e1f05838dcc2d6db65a96d22535d2e3fc02e66ee071885f15732001b7812L66-R66) [[5]](diffhunk://#diff-4314e1f05838dcc2d6db65a96d22535d2e3fc02e66ee071885f15732001b7812L87-R87) [[6]](diffhunk://#diff-4314e1f05838dcc2d6db65a96d22535d2e3fc02e66ee071885f15732001b7812L118-R118) [[7]](diffhunk://#diff-4314e1f05838dcc2d6db65a96d22535d2e3fc02e66ee071885f15732001b7812L143-R143)
* [`packages/core/docs/references/namespaces/Micra/interfaces/ErrorOptions.md`](diffhunk://#diff-9ce7b60364979b73057d1be997bdfed59759422fea6d91f34ef82bc29d7f6580L9-R9): Updated all references to the latest version of `error/index.d.ts`. [[1]](diffhunk://#diff-9ce7b60364979b73057d1be997bdfed59759422fea6d91f34ef82bc29d7f6580L9-R9) [[2]](diffhunk://#diff-9ce7b60364979b73057d1be997bdfed59759422fea6d91f34ef82bc29d7f6580L24-R24) [[3]](diffhunk://#diff-9ce7b60364979b73057d1be997bdfed59759422fea6d91f34ef82bc29d7f6580L49-R49) [[4]](diffhunk://#diff-9ce7b60364979b73057d1be997bdfed59759422fea6d91f34ef82bc29d7f6580L74-R74) [[5]](diffhunk://#diff-9ce7b60364979b73057d1be997bdfed59759422fea6d91f34ef82bc29d7f6580L99-R99) [[6]](diffhunk://#diff-9ce7b60364979b73057d1be997bdfed59759422fea6d91f34ef82bc29d7f6580L134-R134)

### ✅ Checks

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

### ℹ Additional Information

More documentation is planned and will be added at a future time.