### PR TITLE
Rename reparent to addChild

### DIFF
--- a/packages/event-emitter/.performance.mjs
+++ b/packages/event-emitter/.performance.mjs
@@ -37,16 +37,20 @@ suite.add('@micra/event-emitter: dispatch event to multiple wildcard listeners',
 
 suite.add('@micra/event-emitter: propagation chain', () => {
   const chain = [];
-  for (let i = 0; i < 10; i++) {
+  for (let i = 0; i < 5; i++) {
     // Create a new emitter and add it to the chain.
     const emitter = new EventEmitter();
-    const parent = chain[chain.length - 1];
-    if (parent) emitter.reparent(parent);
-    chain.push(emitter);
 
     // Add a listener on the first and last emitter.
     emitter.addEventListener('test', () => {});
     emitter.addEventListener('test', () => {}, true);
+
+    // Assign parent to the emitter
+    const parent = chain[chain.length - 1];
+    if (parent) parent.addChild(emitter);
+
+    // Add the emitter to the chain.
+    chain.push(emitter);
   }
 
   // Dispatch the event from the bottom of the chain.

--- a/packages/event-emitter/docs/how-to/Handle Event Propagation and Bubbling.md
+++ b/packages/event-emitter/docs/how-to/Handle Event Propagation and Bubbling.md
@@ -26,7 +26,7 @@ const childEmitter = new EventEmitter();
 For events to bubble, child emitters need to be linked to a parent.
 
 ```ts
-parentEmitter.reparent(childEmitter);
+parentEmitter.addChild(childEmitter);
 ```
 
 ### Step 3: Register Listeners at Different Levels

--- a/packages/event-emitter/docs/references/EventEmitter/classes/EventEmitter.md
+++ b/packages/event-emitter/docs/references/EventEmitter/classes/EventEmitter.md
@@ -135,8 +135,7 @@ Removes a previously added event listener for a specific event type.
 
 Defined in: [classes/EventEmitter.ts:137](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/event-emitter/src/classes/EventEmitter.ts#L137)
 
-addChilds a child event emitter to this event emitter. This will allow the child to bubble events up to this event emitter.
-
+Adds a child event emitter to this event emitter. This will allow the child to bubble events up to this event emitter.
 #### Parameters
 
 ##### child

--- a/packages/event-emitter/docs/references/EventEmitter/classes/EventEmitter.md
+++ b/packages/event-emitter/docs/references/EventEmitter/classes/EventEmitter.md
@@ -129,13 +129,13 @@ Removes a previously added event listener for a specific event type.
 
 ***
 
-### reparent()
+### addChild()
 
-> **reparent**(`child`): `this`
+> **addChild**(`child`): `this`
 
 Defined in: [classes/EventEmitter.ts:137](https://github.com/micrajs/micra/blob/3b7677b14fc2bb80e62464f4fbe424c9f2241a5a/packages/event-emitter/src/classes/EventEmitter.ts#L137)
 
-Reparents a child event emitter to this event emitter. This will allow the child to bubble events up to this event emitter.
+addChilds a child event emitter to this event emitter. This will allow the child to bubble events up to this event emitter.
 
 #### Parameters
 

--- a/packages/event-emitter/src/classes/EventEmitter.test.ts
+++ b/packages/event-emitter/src/classes/EventEmitter.test.ts
@@ -8,7 +8,7 @@ describe('EventEmitter', () => {
     const listener = vi.fn();
     const root = new EventEmitter();
     const child = new EventEmitter();
-    root.reparent(child);
+    root.addChild(child);
 
     root.addEventListener('test', listener, true);
     child.dispatchEvent(new Event('test'));
@@ -42,8 +42,8 @@ describe('EventEmitter', () => {
     const root = new EventEmitter();
     const child = new EventEmitter();
     const target = new EventEmitter();
-    root.reparent(child);
-    child.reparent(target);
+    root.addChild(child);
+    child.addChild(target);
     root.addEventListener('test', () => listener('root capturing'), {
       capture: true,
     });
@@ -74,8 +74,8 @@ describe('EventEmitter', () => {
     const root = new EventEmitter();
     const child = new EventEmitter();
     const target = new EventEmitter();
-    root.reparent(child);
-    child.reparent(target);
+    root.addChild(child);
+    child.addChild(target);
     root.addEventListener('test', () => listener('root capturing'), {
       capture: true,
     });
@@ -143,8 +143,8 @@ describe('EventEmitter', () => {
     const root = new EventEmitter();
     const child = new EventEmitter();
     const target = new EventEmitter();
-    root.reparent(child);
-    child.reparent(target);
+    root.addChild(child);
+    child.addChild(target);
     const event = new Event('test', {bubbles: false});
     root.addEventListener('test', () => listener('root listener'), {
       capture: true,

--- a/packages/event-emitter/src/classes/EventEmitter.ts
+++ b/packages/event-emitter/src/classes/EventEmitter.ts
@@ -134,7 +134,7 @@ export class EventEmitter<EventMap extends Record<string, any> = Record<string, 
    * @param child Child event emitter
    * @returns This event emitter.
    */
-  reparent(child: Micra.EventEmitter<any> | EventEmitter): this {
+  addChild(child: Micra.EventEmitter<any> | EventEmitter): this {
     (child as EventEmitter)[EVENT_EMITTER_PARENT] = this;
     return this;
   }


### PR DESCRIPTION

### 📑 Summary

This pull request refactors the `EventEmitter` class by renaming the `reparent` method to `addChild` for improved clarity and consistency. The changes also update related documentation, tests, and performance benchmarks to reflect this renaming.

### Method Renaming in `EventEmitter`:

* Renamed the `reparent` method to `addChild` in the `EventEmitter` class for better semantic clarity. Updated the method implementation in `EventEmitter.ts`.

### Documentation Updates:

* Updated references to the `reparent` method in the documentation files to reflect the new `addChild` method name. This includes updates in `Handle Event Propagation and Bubbling.md` and `EventEmitter.md`. [[1]](diffhunk://#diff-c98b57f15ef32d517e31fb5b1c5d7dd53abb20d9edbf3c74229ce34bcff14f71L29-R29) [[2]](diffhunk://#diff-88a774d0c4a921f1f1669ed105c7384a2337d37e607e1a5e1f44d5a3782d8c89L132-R138)

### Test Updates:

* Replaced all instances of `reparent` with `addChild` in the test cases for the `EventEmitter` class, ensuring alignment with the new method name. [[1]](diffhunk://#diff-9f4378230e42181de52742e0e0bf65189e91ad064ea9b57e47e1e8351aa9d18cL11-R11) [[2]](diffhunk://#diff-9f4378230e42181de52742e0e0bf65189e91ad064ea9b57e47e1e8351aa9d18cL45-R46) [[3]](diffhunk://#diff-9f4378230e42181de52742e0e0bf65189e91ad064ea9b57e47e1e8351aa9d18cL77-R78) [[4]](diffhunk://#diff-9f4378230e42181de52742e0e0bf65189e91ad064ea9b57e47e1e8351aa9d18cL146-R147)

### Performance Benchmark Updates:

* Adjusted the performance benchmark in `.performance.mjs` to use the renamed `addChild` method and reduced the chain size from 10 to 5 for testing purposes.

### ✅ Checks

<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->

- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed